### PR TITLE
fix: restrictions grammar

### DIFF
--- a/src/tools/monaco/language-definition.ts
+++ b/src/tools/monaco/language-definition.ts
@@ -61,35 +61,14 @@ export const language = <MonacoEditor.languages.IMonarchLanguage>{
 
   tokenizer: {
     root: [
-      { include: "@cel_symbol" },
       { include: "@whitespace" },
 
       [new RegExp(/^(\s*#).*/), OpenFgaDslThemeToken.COMMENT],
 
-      [
-        new RegExp(/(\[)(\s*)(@identifiers)(\s*)(\])/),
-        ["@brackets", "@whitespace", OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_TYPE, "@whitespace", "@brackets"],
-      ],
-      [
-        new RegExp(/(,)(\s*)(@identifiers)(\s*)(\])/),
-        [
-          OpenFgaDslThemeToken.DELIMITER_COMMA_TYPE_RESTRICTIONS,
-          "@whitespace",
-          OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_TYPE,
-          "@whitespace",
-          "@brackets",
-        ],
-      ],
-      [
-        new RegExp(/(\[)(\s*)(@identifiers)(\s*)(,)/),
-        [
-          "@brackets",
-          "@whitespace",
-          OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_TYPE,
-          "@whitespace",
-          OpenFgaDslThemeToken.DELIMITER_COMMA_TYPE_RESTRICTIONS,
-        ],
-      ],
+      [new RegExp(/(\[)/), "@brackets", "@restrictions"],
+
+      [new RegExp(/(\{)/), "@brackets", "@cel_symbols"],
+
       [new RegExp(/[{}[\]()]/), "@brackets"],
 
       [
@@ -116,7 +95,6 @@ export const language = <MonacoEditor.languages.IMonarchLanguage>{
         new RegExp(/(but not)(\s+)(@identifiers)/),
         [OpenFgaDslThemeToken.OPERATOR_BUT_NOT, "@whitespace", OpenFgaDslThemeToken.VALUE_RELATION_COMPUTED],
       ],
-      [new RegExp(/(\s+)(with)(\s+)/), ["@whitespace", OpenFgaDslThemeToken.KEYWORD_WITH, "@whitespace"]],
       [
         new RegExp(/(as)(\s+)(@identifiers)/),
         [OpenFgaDslThemeToken.KEYWORD_AS, "@whitespace", OpenFgaDslThemeToken.VALUE_RELATION_COMPUTED],
@@ -136,25 +114,18 @@ export const language = <MonacoEditor.languages.IMonarchLanguage>{
         ],
       ],
       [
-        new RegExp(/(@identifiers)(#)(@identifiers)/),
+        new RegExp(/(@identifiers)(\s*)(:)(\s*)(@identifiers)(<@identifiers>)(,?)(\s*)/),
         [
-          OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_TYPE,
-          OpenFgaDslThemeToken.DELIMITER_HASHTAG_TYPE_RESTRICTIONS,
-          OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_RELATION,
+          OpenFgaDslThemeToken.CONDITION_PARAM,
+          "@whitespace",
+          OpenFgaDslThemeToken.DELIMITER_COLON_CONDITION_PARAM,
+          "@whitespace",
+          OpenFgaDslThemeToken.CONDITION_PARAM_TYPE,
+          OpenFgaDslThemeToken.CONDITION_PARAM_TYPE,
+          OpenFgaDslThemeToken.DELIMITER_COMMA_CONDITION_PARAM,
+          "@whitespace",
         ],
       ],
-      [
-        new RegExp(/(@identifiers)(:)(\*)/),
-        [
-          OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_TYPE,
-          OpenFgaDslThemeToken.DELIMITER_COLON_TYPE_RESTRICTIONS,
-          OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_WILDCARD,
-        ],
-      ],
-
-      [/"/, "string", "@string_double"],
-      [/'/, "string", "@string_single"],
-
       [
         new RegExp(/(@identifiers)(\s*)(:)(\s*)(@identifiers)(,?)(\s*)/),
         [
@@ -206,7 +177,14 @@ export const language = <MonacoEditor.languages.IMonarchLanguage>{
       ],
     ],
 
-    cel_symbol: [[/(<|<=|>=|>|=|!=|&&|\|\||\.|null|in)/, OpenFgaDslThemeToken.CONDITION_SYMBOL]],
+    cel_symbols: [
+      [/"/, "string", "@string_double"],
+      [/'/, "string", "@string_single"],
+      [/(\w|-[a-zA-Z])+/, OpenFgaDslThemeToken.CONDITION_SYMBOL],
+      [/(<|<=|>=|>|=|!=|&&|\|\||\.|null|in)/, OpenFgaDslThemeToken.CONDITION_SYMBOL],
+      [/\[|\]|\(|\)/, "@brackets"],
+      [/\}/, "@brackets", "@pop"],
+    ],
 
     string_double: [
       [/[^\\"]+/, "string"],
@@ -218,6 +196,19 @@ export const language = <MonacoEditor.languages.IMonarchLanguage>{
       [/[^\\']+/, "string"],
       [/\\./, "string.escape.invalid"],
       [/'/, "string", "@pop"],
+    ],
+
+    restrictions: [
+      { include: "@whitespace" },
+      [new RegExp(`${Keyword.WITH}`), OpenFgaDslThemeToken.KEYWORD_WITH],
+      [/(\w|-[a-zA-Z])+/, OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_TYPE],
+      [
+        /(:)(\*)/,
+        [OpenFgaDslThemeToken.DELIMITER_COLON_TYPE_RESTRICTIONS, OpenFgaDslThemeToken.VALUE_TYPE_RESTRICTIONS_WILDCARD],
+      ],
+      [/#/, OpenFgaDslThemeToken.DELIMITER_HASHTAG_TYPE_RESTRICTIONS],
+      [/,/, OpenFgaDslThemeToken.DELIMITER_COMMA_TYPE_RESTRICTIONS],
+      [/\]/, "@brackets", "@pop"],
     ],
 
     // Deal with white space, including comments


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

There is more work that can be done to clean up this language definition, but for now I've done the following:

* Re-organize grammar to leverage state while parsing `[ ]` content
* Pulled out `cel_symbols` into their own state while parsing `{ }` content
* Remove redundant declarations

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
