### PR TITLE
fix(moncaco/validate): handle metadata being undefined

### DIFF
--- a/src/tools/monaco/validate.ts
+++ b/src/tools/monaco/validate.ts
@@ -26,15 +26,17 @@ export function validateDSL(monaco: typeof MonacoEditor, dsl: string): Marker[] 
       }
 
       const extraInformation: Marker["extraInformation"] = {};
-      const errorMetadata = singleErr.metadata as any;
-      if (errorMetadata.errorType) {
-        extraInformation.error = errorMetadata.errorType;
-      }
-      ["typeName", "relation"].forEach((field) => {
-        if (errorMetadata[field]) {
-          (extraInformation as any)[field] = errorMetadata[field];
+      const errorMetadata = singleErr.metadata;
+      if (errorMetadata) {
+        if ("errorType" in errorMetadata) {
+          extraInformation.error = errorMetadata.errorType;
         }
-      });
+        ["typeName", "relation"].forEach((field) => {
+          if (field in errorMetadata) {
+            (extraInformation as any)[field] = (errorMetadata as any)[field];
+          }
+        });
+      }
 
       markers.push({
         message: singleErr.msg,


### PR DESCRIPTION
## Description

It's possible for an error returned from the `validateDSL` method in `language` to return no metadata ([1](https://github.com/openfga/language/blob/d4c79707596a3fd8548ebd63c32630d57c1a3b0f/pkg/js/errors.ts#L75), [2](https://github.com/openfga/language/blob/d4c79707596a3fd8548ebd63c32630d57c1a3b0f/pkg/js/errors.ts#L75)), based on documentation/the source code from ANTRL this would indicate that the error arose from the lexer but unfortunately I've not been able to come up with a case where I can reproduce this to write a test from.

That said, based on the error shown in Sentry and the surrounding code this is a fairly certain fix for the issue.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
