### PR TITLE
ci: replace existing github release creation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -120,8 +120,17 @@ jobs:
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
-      - uses: Roang-zero1/github-create-release-action@57eb9bdce7a964e48788b9e78b5ac766cb684803 # v3.0.1
+      - id: extract-changelog
+        uses: dahlia/submark@7d44d75a4dcfd351258491f26898e836b0521ce0 # v0.3.1
         with:
-          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
+          input-file: CHANGELOG.md
+          heading-level: 2
+          heading-title-text: ${{ github.ref_name }}
+          ignore-case: true
+          omit-heading: true
+
+      - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
+        with:
+          body: ${{ steps.extract-changelog.outputs.output-text }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Given the issue with the existing action around newlines, I figured it was worth a quick look into replacing it.

The existing action uses a tool called [submark](https://github.com/dahlia/submark) to parse the changelog for the release body, this offers an action that we can use to do the same and then feed the output of that into a maintained action for creating a release (we've used this before in Auth0 SDKs).

This is entirely untested so is in draft status, if we decide we wanna give it a try then I will experiment on a personal repo to ensure I have a working flow before attempting to roll out.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
