### PR TITLE
Enhance Highlighting Customization for `OpenFgaDsl` Language

### DIFF
--- a/src/tools/prism/language-definition.ts
+++ b/src/tools/prism/language-definition.ts
@@ -1,26 +1,29 @@
 import { OpenFgaDslThemeTokenType } from "../../theme/theme.typings";
 
 export const languageDefinition = {
-  [OpenFgaDslThemeTokenType.MODULE]: {
+  module: {
     pattern: /(module\s+)[\w_-]+/i,
-    lookbehind: true,
+    alias: OpenFgaDslThemeTokenType.MODULE,
   },
-  [OpenFgaDslThemeTokenType.TYPE]: {
+  type: {
     pattern: /(\btype\s+)[\w_-]+/i,
-    lookbehind: true,
+    alias: OpenFgaDslThemeTokenType.TYPE,
   },
-  [OpenFgaDslThemeTokenType.EXTEND]: {
+  "extend-type": {
     pattern: /(\bextend type\s+)[\w_-]+/i,
-    lookbehind: true,
+    alias: OpenFgaDslThemeTokenType.EXTEND,
   },
-  [OpenFgaDslThemeTokenType.RELATION]: {
+  relation: {
     pattern: /(\bdefine\s+)[\w_-]+/i,
-    lookbehind: true,
+    alias: OpenFgaDslThemeTokenType.RELATION,
   },
-  [OpenFgaDslThemeTokenType.DIRECTLY_ASSIGNABLE]: /\[.*]|self/,
-  [OpenFgaDslThemeTokenType.CONDITION]: {
+  "directly-assignable": {
+    pattern: /\[.*]|self/,
+    alias: OpenFgaDslThemeTokenType.DIRECTLY_ASSIGNABLE,
+  },
+  condition: {
     pattern: /(\bcondition\s+)[\w_-]+/i,
-    lookbehind: true,
+    alias: OpenFgaDslThemeTokenType.CONDITION,
   },
   "condition-params": {
     pattern: /\(.*\)\s*{/,
@@ -29,10 +32,12 @@ export const languageDefinition = {
       "condition-param-type": /\b(string|int|map|uint|list|timestamp|bool|duration|double|ipaddress)\b/,
     },
   },
-  [OpenFgaDslThemeTokenType.COMMENT]: {
+  comment: {
     pattern: /(^\s*|\s+)#.*/,
+    alias: OpenFgaDslThemeTokenType.COMMENT,
   },
-  [OpenFgaDslThemeTokenType.KEYWORD]: {
+  keyword: {
     pattern: /\b(type|relations|define|and|or|but not|from|as|model|schema|condition|module|extend)\b/,
+    alias: OpenFgaDslThemeTokenType.KEYWORD,
   },
 };


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR aims to enhance the customization of syntax highlighting for the OpenFgaDsl language definition. 

**Changes:**
- Restructured the tokens in the language definition to use the default PrismJS tokens.
- Added alias mappings to maintain the connection with the original `OpenFgaDslThemeTokenType` enum values.

This change will make it easier for users to customize the highlighting colors without needing to add the OpenFGA specific CSS. It provides a more seamless integration with the default PrismJS themes and improves the overall DevX when working with `OpenFgaDsl` code.

### Why this approach?

In this, each token in the `languageDefinition` object has been given a more descriptive name that aligns with the default PrismJS tokens. The `alias` property is used to maintain the mapping to the original `OpenFgaDslThemeTokenType` enum values.


This approach allows for easier customization of the highlighting colors by utilizing the default PrismJS tokens, while still keeping the internal mapping to the specific `OpenFgaDslThemeTokenType` enum values.




## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #177

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
